### PR TITLE
Fix for Unused import

### DIFF
--- a/client/storage/db.py
+++ b/client/storage/db.py
@@ -1,5 +1,4 @@
 import json
-import os
 import sqlite3
 from contextlib import contextmanager, suppress
 from datetime import datetime, timezone


### PR DESCRIPTION
The fix is to remove the unused `os` import from `client/storage/db.py`.

Best implementation without changing functionality:
- Edit the import block at the top of `client/storage/db.py`.
- Delete `import os` (line 2 in the snippet).
- Keep all other imports unchanged.

No new methods, definitions, or dependencies are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._