### PR TITLE
Fix for Unused import

### DIFF
--- a/tests/e2e/test_e2e.py
+++ b/tests/e2e/test_e2e.py
@@ -3,7 +3,6 @@ End-to-End Integration Test Suite for Fortress Messenger
 Tests all 9 core properties of the system in a continuous flow.
 """
 
-import pytest
 import asyncio
 import base64
 import json


### PR DESCRIPTION
Remove the unused `pytest` import from `tests/e2e/test_e2e.py`.

- General fix: delete imports that are not referenced anywhere in the module.
- Best fix here: remove only `import pytest` at the top of the file, leaving all other imports unchanged.
- File/region: `tests/e2e/test_e2e.py`, import block near lines 6–12.
- No new methods, definitions, or dependencies are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._